### PR TITLE
Added support for shared nozzle used by Prusa's MMU2

### DIFF
--- a/ui/idle_status.go
+++ b/ui/idle_status.go
@@ -144,6 +144,10 @@ func (m *idleStatusPanel) defineToolsCount() int {
 		return 0
 	}
 
+	if profile.Extruder.SharedNozzle {
+		return 1
+	}
+
 	return profile.Extruder.Count
 }
 

--- a/ui/print_status.go
+++ b/ui/print_status.go
@@ -298,6 +298,10 @@ func (m *printStatusPanel) defineToolsCount() int {
 		return 0
 	}
 
+	if profile.Extruder.SharedNozzle {
+		return 1
+	}
+
 	return profile.Extruder.Count
 }
 

--- a/vendor/github.com/mcuadros/go-octoprint/common.go
+++ b/vendor/github.com/mcuadros/go-octoprint/common.go
@@ -864,5 +864,6 @@ type PrinterProfile struct {
 
 	Extruder struct {
 		Count int `json:"count"`
+		SharedNozzle bool `json:"sharedNozzle"`
 	} `json:"extruder"`
 }


### PR DESCRIPTION
This change solves missing information about bed and hotend in the info screens and adds support for the shared nozzle setting in octoprint.