### PR TITLE
fix 2.6.0 build

### DIFF
--- a/ui/IdleStatusPanel.go
+++ b/ui/IdleStatusPanel.go
@@ -77,14 +77,14 @@ func (this *idleStatusPanel) showTools() {
 	// and they can't be reused.
 	toolheadCount := utils.GetToolheadCount(this.UI.Client)
 	if toolheadCount == 1 {
-		this.tool0Button = uiWidgets.CreteToolButton(0, this.UI.Client)
+		this.tool0Button = uiWidgets.CreateToolButton(0, this.UI.Client)
 	} else {
-		this.tool0Button = uiWidgets.CreteToolButton(1, this.UI.Client)
+		this.tool0Button = uiWidgets.CreateToolButton(1, this.UI.Client)
 	}
-	this.tool1Button = uiWidgets.CreteToolButton( 2, this.UI.Client)
-	this.tool2Button = uiWidgets.CreteToolButton( 3, this.UI.Client)
-	this.tool3Button = uiWidgets.CreteToolButton( 4, this.UI.Client)
-	this.bedButton   = uiWidgets.CreteToolButton(-1, this.UI.Client)
+	this.tool1Button = uiWidgets.CreateToolButton(2, this.UI.Client)
+	this.tool2Button = uiWidgets.CreateToolButton(3, this.UI.Client)
+	this.tool3Button = uiWidgets.CreateToolButton(4, this.UI.Client)
+	this.bedButton = uiWidgets.CreateToolButton(-1, this.UI.Client)
 
 	switch toolheadCount {
 		case 1:

--- a/ui/PrintStatusPanel.go
+++ b/ui/PrintStatusPanel.go
@@ -16,21 +16,21 @@ var printStatusPanelInstance *printStatusPanel
 type printStatusPanel struct {
 	CommonPanel
 
-	progressBar			*gtk.ProgressBar
+	progressBar *gtk.ProgressBar
 
-	tool0Button			*gtk.Button
-	tool1Button			*gtk.Button
-	tool2Button			*gtk.Button
-	tool3Button			*gtk.Button
-	bedButton  			*gtk.Button
+	tool0Button *uiWidgets.ToolButton
+	tool1Button *uiWidgets.ToolButton
+	tool2Button *uiWidgets.ToolButton
+	tool3Button *uiWidgets.ToolButton
+	bedButton   *uiWidgets.ToolButton
 
-	fileLabel			*utils.LabelWithImage
-	timeLabel			*utils.LabelWithImage
-	timeLeftLabel		*utils.LabelWithImage
-	completeButton		*gtk.Button
-	pauseButton			*gtk.Button
-	stopButton			*gtk.Button
-	menuButton			*gtk.Button
+	fileLabel      *utils.LabelWithImage
+	timeLabel      *utils.LabelWithImage
+	timeLeftLabel  *utils.LabelWithImage
+	completeButton *gtk.Button
+	pauseButton    *gtk.Button
+	stopButton     *gtk.Button
+	menuButton     *gtk.Button
 }
 
 func PrintStatusPanel(ui *UI) *printStatusPanel {
@@ -71,14 +71,14 @@ func (this *printStatusPanel) showTools() {
 	// and they can't be reused.
 	toolheadCount := utils.GetToolheadCount(this.UI.Client)
 	if toolheadCount == 1 {
-		this.tool0Button = uiWidgets.CreateToolPrintingButton(0)
+		this.tool0Button = uiWidgets.CreateToolButton(0, this.UI.Client)
 	} else {
-		this.tool0Button = uiWidgets.CreateToolPrintingButton(1)
+		this.tool0Button = uiWidgets.CreateToolButton(1, this.UI.Client)
 	}
-	this.tool1Button = uiWidgets.CreateToolPrintingButton( 2)
-	this.tool2Button = uiWidgets.CreateToolPrintingButton( 3)
-	this.tool3Button = uiWidgets.CreateToolPrintingButton( 4)
-	this.bedButton   = uiWidgets.CreateToolPrintingButton(-1)
+	this.tool1Button = uiWidgets.CreateToolButton(2, this.UI.Client)
+	this.tool2Button = uiWidgets.CreateToolButton(3, this.UI.Client)
+	this.tool3Button = uiWidgets.CreateToolButton(4, this.UI.Client)
+	this.bedButton = uiWidgets.CreateToolButton(-1, this.UI.Client)
 
 	switch toolheadCount {
 		case 1:

--- a/uiWidgets/ToolButton.go
+++ b/uiWidgets/ToolButton.go
@@ -46,9 +46,9 @@ type ToolButton struct {
 	printer			*octoprint.Client
 }
 
-func CreteToolButton(
-	index			int,
-	printer			*octoprint.Client,
+func CreateToolButton(
+	index int,
+	printer *octoprint.Client,
 ) *ToolButton {
 	imageFileName := ToolImageFileName(index)
 	toolName := ToolName(index)
@@ -61,7 +61,7 @@ func CreteToolButton(
 
 	_, err := instance.Connect("clicked", instance.clicked)
 	if err != nil {
-		utils.LogError("ToolButton.CreteToolButton()", "t.Connect('clicked', t.clicked)", err)
+		utils.LogError("ToolButton.CreateToolButton()", "t.Connect('clicked', t.clicked)", err)
 	}
 
 	return instance


### PR DESCRIPTION
I was just testing the 2.6.0-dev branch and noticed some errors and a typo which was failing "make build"...afterwards it's running pretty fine again :+1: 


Full log of "make build":
```
	rm -f debian/*.debhelper.log
   debian/rules override_dh_auto_build
make[2]: Entering directory '/go/src/github.com/Z-Bolt/OctoScreen'
dh_auto_build -O--buildsystem=golang -O--no-parallel -- \
	--tags gtk_3_22 \
	-ldflags "\
		-X github.com/Z-Bolt/OctoScreen/ui.Version=2.6 \
		-X github.com/Z-Bolt/OctoScreen/ui.Build=20201115-17:17:38\
	"
	cd obj-x86_64-linux-gnu
	go install -v -p 1 --tags gtk_3_22 -ldflags "		-X github.com/Z-Bolt/OctoScreen/ui.Version=2.6 		-X github.com/Z-Bolt/OctoScreen/ui.Build=20201115-17:17:38	" github.com/Z-Bolt/OctoScreen github.com/Z-Bolt/OctoScreen/interfaces github.com/Z-Bolt/OctoScreen/ui github.com/Z-Bolt/OctoScreen/uiWidgets github.com/Z-Bolt/OctoScreen/utils
github.com/Z-Bolt/OctoScreen/vendor/github.com/gotk3/gotk3/glib
github.com/Z-Bolt/OctoScreen/vendor/github.com/gotk3/gotk3/cairo
github.com/Z-Bolt/OctoScreen/vendor/github.com/gotk3/gotk3/gdk
github.com/Z-Bolt/OctoScreen/vendor/github.com/gotk3/gotk3/pango
github.com/Z-Bolt/OctoScreen/vendor/github.com/gotk3/gotk3/gtk
github.com/Z-Bolt/OctoScreen/vendor/github.com/mcuadros/go-octoprint
github.com/Z-Bolt/OctoScreen/interfaces
github.com/Z-Bolt/OctoScreen/vendor/golang.org/x/sys/unix
github.com/Z-Bolt/OctoScreen/vendor/golang.org/x/crypto/ssh/terminal
github.com/Z-Bolt/OctoScreen/vendor/github.com/sirupsen/logrus
github.com/Z-Bolt/OctoScreen/utils
github.com/Z-Bolt/OctoScreen/vendor/github.com/dustin/go-humanize
github.com/Z-Bolt/OctoScreen/vendor/github.com/shirou/gopsutil/internal/common
github.com/Z-Bolt/OctoScreen/vendor/github.com/shirou/gopsutil/load
github.com/Z-Bolt/OctoScreen/vendor/github.com/shirou/gopsutil/mem
github.com/Z-Bolt/OctoScreen/uiWidgets
github.com/Z-Bolt/OctoScreen/vendor/github.com/coreos/go-systemd/daemon
github.com/Z-Bolt/OctoScreen/vendor/github.com/golang-collections/collections/stack
github.com/Z-Bolt/OctoScreen/vendor/pifke.org/wpasupplicant
github.com/Z-Bolt/OctoScreen/ui
# github.com/Z-Bolt/OctoScreen/ui
src/github.com/Z-Bolt/OctoScreen/ui/PrintStatusPanel.go:74:22: undefined: uiWidgets.CreateToolPrintingButton
src/github.com/Z-Bolt/OctoScreen/ui/PrintStatusPanel.go:76:22: undefined: uiWidgets.CreateToolPrintingButton
src/github.com/Z-Bolt/OctoScreen/ui/PrintStatusPanel.go:78:21: undefined: uiWidgets.CreateToolPrintingButton
src/github.com/Z-Bolt/OctoScreen/ui/PrintStatusPanel.go:79:21: undefined: uiWidgets.CreateToolPrintingButton
src/github.com/Z-Bolt/OctoScreen/ui/PrintStatusPanel.go:80:21: undefined: uiWidgets.CreateToolPrintingButton
src/github.com/Z-Bolt/OctoScreen/ui/PrintStatusPanel.go:81:21: undefined: uiWidgets.CreateToolPrintingButton
github.com/Z-Bolt/OctoScreen/vendor/gopkg.in/yaml.v1
dh_auto_build: go install -v -p 1 --tags gtk_3_22 -ldflags 		-X github.com/Z-Bolt/OctoScreen/ui.Version=2.6 		-X github.com/Z-Bolt/OctoScreen/ui.Build=20201115-17:17:38	 github.com/Z-Bolt/OctoScreen github.com/Z-Bolt/OctoScreen/interfaces github.com/Z-Bolt/OctoScreen/ui github.com/Z-Bolt/OctoScreen/uiWidgets github.com/Z-Bolt/OctoScreen/utils returned exit code 2
	cd /go/src/github.com/Z-Bolt/OctoScreen
debian/rules:12: recipe for target 'override_dh_auto_build' failed
make[2]: *** [override_dh_auto_build] Error 2
make[2]: Leaving directory '/go/src/github.com/Z-Bolt/OctoScreen'
debian/rules:9: recipe for target 'build' failed
make[1]: *** [build] Error 2
make[1]: Leaving directory '/go/src/github.com/Z-Bolt/OctoScreen'
dpkg-buildpackage: error: debian/rules build gave error exit status 2
debuild: fatal error at line 1116:
dpkg-buildpackage -rfakeroot -us -uc failed
cp: cannot stat '../*.deb': No such file or directory
Makefile:62: recipe for target 'build-internal' failed
make: *** [build-internal] Error 1
make: *** [Makefile:51: STRETCH] Fehler 2
```
