### PR TITLE
Potential MakeFile Development Version Changes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,9 +31,10 @@ JESSIE_GO_TAGS := gtk_3_14
 
 
 # Build information
+# This indicates that the versioning scheme has been changed and ensures that the package manager will order historical versions correctly
 VERSION_EPOCH := 1
 GIT_COMMIT != git rev-parse HEAD | cut -c1-7
-VERSION != git name-rev --tags --name-only $(GIT_COMMIT) | sed -e 's/(^[^0-9]+|[^0-9.])//g'
+VERSION != git name-rev --tags --name-only $(shell git rev-list --tags --max-count=1) | sed -e 's/(^[^0-9]+|[^0-9.])//g'
 BRANCH != git rev-parse --abbrev-ref HEAD
 
 # If this isn't the master branch, add additional development version information
@@ -44,7 +45,7 @@ ifneq ($(BRANCH), master)
     VERSION := $(VERSION)+$(shell git rev-list --count HEAD ^master)
     # Add the current commit SHA (abreviated)
     VERSION := $(VERSION):$(GIT_COMMIT)
-    # Add dirty indicator
+    # Add dirty indicator (un-committed changes)
     ifneq ($(shell git status --short | wc -l), 0)
         VERSION := $(VERSION)-dirty
     endif


### PR DESCRIPTION
The pattern here is based off a number of other sources I found, that suggest including the branch, commit, and distance from master.  As well as an indicator of wether or not the build was off a dirty tree with uncommitted or tracked changes.

There are probably better ways to do this, perhaps with BUILD numbers, or something, but this is just a baseline suggestion.

I feel something needs to be added to track this, if other devs are going to be testing changes for submission.  This is not a final suggestion for 'how', but just an earmark for one way it could be done.

**Of note**:

- If building off branch `master`, the `deb` name is:
  `octoscreen_2.6.1-1_armhf.deb`
- If building off the latest commit in this PR, the name is:
  `octoscreen_2.6.1~IMPDevelopmentVersions+2:c219513-dirty-1_armhf.deb`
  Which indicates:
  - We are on branch `IMPDevelopmentVersions` (slashes removed for sanitization)
  - The branch was, at the time of `Build`, 2 commits ahead of `master` (this is to be considered, as well, 2 commits ahead of the `2.6.1` tag, as those are what is committed to `master`).
  - The latest commit's SHA is `c219513`
  - The working directory was `dirty` at the time of build (contained un-committed or tracked changes)

**Granted:** Not many people are going to be building `deb`s for this on their own, but for those of us who are, having a sane and readable versioning pattern will help A LOT.  :-D