### PR TITLE
Imp/auto local

### DIFF
--- a/ui/FilesPanel.go
+++ b/ui/FilesPanel.go
@@ -51,6 +51,7 @@ func FilesPanel(
 }
 
 func (this *filesPanel) initialize() {
+	logger.Info("Begin (*filesPanel).initialize()")
 	this.listBox = utils.MustBox(gtk.ORIENTATION_VERTICAL, 0)
 	this.listBox.SetVExpand(true)
 
@@ -64,6 +65,7 @@ func (this *filesPanel) initialize() {
 	this.Grid().Add(box)
 
 	this.doLoadFiles()
+	logger.Info("End (*filesPanel).initialize()")
 }
 
 func (this *filesPanel) createActionFooter() *gtk.Box {
@@ -94,12 +96,16 @@ func (this *filesPanel) createBackButton() *gtk.Button {
 }
 
 func (this *filesPanel) doLoadFiles() {
+	logger.Info("Begin (*filesPanel).doLoadFiles()")
 	utils.EmptyTheContainer(&this.listBox.Container)
 
 	if this.isRoot() {
+		logger.Info("Determined True (*filesPanel).isRoot()")
 		if this.refreshSD() {
+			logger.Info("Determined True (*filesPanel).refreshSD()")
 			this.addRootLocations()
 		} else {
+			logger.Info("Determined False (*filesPanel).refreshSD()")
 			this.locationHistory = utils.LocationHistory {
 				Locations: []dataModels.Location{dataModels.Local},
 			}
@@ -107,11 +113,13 @@ func (this *filesPanel) doLoadFiles() {
 	}
 	
 	if !this.isRoot() {
+		logger.Info("Determined False (*filesPanel).isRoot()")
 		sortedFiles := this.getSortedFiles()
 		this.addSortedFiles(sortedFiles)
 	}
 
 	this.listBox.ShowAll()
+	logger.Info("End (*filesPanel).doLoadFiles()")
 }
 
 func (this *filesPanel) refreshSD() bool {

--- a/ui/FilesPanel.go
+++ b/ui/FilesPanel.go
@@ -115,7 +115,7 @@ func (this *filesPanel) doLoadFiles() {
 }
 
 func (this *filesPanel) refreshSD() bool {
-	sdResponse, err := (&octoprintApis.SdRefreshRequest {}).Do(this.UI.Client)
+	err := (&octoprintApis.SdRefreshRequest {}).Do(this.UI.Client)
 	if err == nil {
 		return true
 	} else {

--- a/ui/FilesPanel.go
+++ b/ui/FilesPanel.go
@@ -96,16 +96,16 @@ func (this *filesPanel) createBackButton() *gtk.Button {
 }
 
 func (this *filesPanel) doLoadFiles() {
-	logger.Info("Begin (*filesPanel).doLoadFiles()")
+	logger.Infof("Begin (*filesPanel).doLoadFiles(%s)", "nb")
 	utils.EmptyTheContainer(&this.listBox.Container)
 
 	if this.isRoot() {
-		logger.Info("Determined True (*filesPanel).isRoot()")
+		logger.Infof("Determined True (*filesPanel).isRoot(%s)", "nb")
 		if this.refreshSD() {
-			logger.Info("Determined True (*filesPanel).refreshSD()")
+			logger.Infof("Determined True (*filesPanel).refreshSD(%s)", "nb")
 			this.addRootLocations()
 		} else {
-			logger.Info("Determined False (*filesPanel).refreshSD()")
+			logger.Infof("Determined False (*filesPanel).refreshSD(%s)", "nb")
 			this.locationHistory = utils.LocationHistory {
 				Locations: []dataModels.Location{dataModels.Local},
 			}
@@ -113,13 +113,13 @@ func (this *filesPanel) doLoadFiles() {
 	}
 	
 	if !this.isRoot() {
-		logger.Info("Determined False (*filesPanel).isRoot()")
+		logger.Infof("Determined False (*filesPanel).isRoot()", "nb")
 		sortedFiles := this.getSortedFiles()
 		this.addSortedFiles(sortedFiles)
 	}
 
 	this.listBox.ShowAll()
-	logger.Info("End (*filesPanel).doLoadFiles()")
+	logger.Infof("End (*filesPanel).doLoadFiles()", "nb")
 }
 
 func (this *filesPanel) refreshSD() bool {

--- a/ui/FilesPanel.go
+++ b/ui/FilesPanel.go
@@ -96,7 +96,7 @@ func (this *filesPanel) createBackButton() *gtk.Button {
 func (this *filesPanel) doLoadFiles() {
 	utils.EmptyTheContainer(&this.listBox.Container)
 	if this.isRoot() {
-		if this.refreshSD() {
+		if this.sdReady() {
 			this.addRootLocations()
 		} else {
 			this.locationHistory = utils.LocationHistory {
@@ -111,7 +111,7 @@ func (this *filesPanel) doLoadFiles() {
 	this.listBox.ShowAll()
 }
 
-func (this *filesPanel) refreshSD() bool {
+func (this *filesPanel) sdReady() bool {
 	err := (&octoprintApis.SdRefreshRequest {}).Do(this.UI.Client)
 	if err == nil {
 		sdState, err := (&octoprintApis.SdStateRequest {}).Do(this.UI.Client)
@@ -130,7 +130,7 @@ func (this *filesPanel) goBack() {
 		this.UI.GoToPreviousPanel()
 	} else if this.locationHistory.IsRoot() {
 		this.locationHistory.GoBack()
-		if this.refreshSD() {
+		if this.sdReady() {
 			this.doLoadFiles()
 		} else {
 			this.UI.GoToPreviousPanel()

--- a/ui/FilesPanel.go
+++ b/ui/FilesPanel.go
@@ -34,7 +34,9 @@ func FilesPanel(
 	ui					*UI,
 	parentPanel			interfaces.IPanel,
 ) *filesPanel {
+	logger.Info("Begin filesPanel()")
 	if filesPanelInstance == nil {
+		logger.Info("Making New filesPanel")
 		locationHistory := utils.LocationHistory {
 			Locations: []dataModels.Location{},
 		}
@@ -47,6 +49,7 @@ func FilesPanel(
 		filesPanelInstance = instance
 	}
 
+	logger.Info("End filesPanel()")
 	return filesPanelInstance
 }
 

--- a/ui/FilesPanel.go
+++ b/ui/FilesPanel.go
@@ -34,9 +34,7 @@ func FilesPanel(
 	ui					*UI,
 	parentPanel			interfaces.IPanel,
 ) *filesPanel {
-	logger.Info("Begin filesPanel()")
 	if filesPanelInstance == nil {
-		logger.Info("Making New filesPanel")
 		locationHistory := utils.LocationHistory {
 			Locations: []dataModels.Location{},
 		}
@@ -49,7 +47,6 @@ func FilesPanel(
 		filesPanelInstance = instance
 	}
 
-	logger.Info("End filesPanel()")
 	return filesPanelInstance
 }
 

--- a/ui/FilesPanel.go
+++ b/ui/FilesPanel.go
@@ -128,7 +128,12 @@ func (this *filesPanel) doLoadFiles() {
 func (this *filesPanel) refreshSD() bool {
 	err := (&octoprintApis.SdRefreshRequest {}).Do(this.UI.Client)
 	if err == nil {
-		return true
+		sdState, err := (&octoprintApis.SdStateRequest {}).Do(this.UI.Client)
+		if err == nil && sdState.IsReady == true {
+			return true
+		} else {
+			return false
+		}
 	} else {
 		return false
 	}

--- a/ui/FilesPanel.go
+++ b/ui/FilesPanel.go
@@ -54,7 +54,6 @@ func FilesPanel(
 }
 
 func (this *filesPanel) initialize() {
-	logger.Info("Begin (*filesPanel).initialize()")
 	this.listBox = utils.MustBox(gtk.ORIENTATION_VERTICAL, 0)
 	this.listBox.SetVExpand(true)
 
@@ -68,7 +67,6 @@ func (this *filesPanel) initialize() {
 	this.Grid().Add(box)
 
 	this.doLoadFiles()
-	logger.Info("End (*filesPanel).initialize()")
 }
 
 func (this *filesPanel) createActionFooter() *gtk.Box {
@@ -99,30 +97,21 @@ func (this *filesPanel) createBackButton() *gtk.Button {
 }
 
 func (this *filesPanel) doLoadFiles() {
-	logger.Infof("Begin (*filesPanel).doLoadFiles(%s)", "nb")
 	utils.EmptyTheContainer(&this.listBox.Container)
-
 	if this.isRoot() {
-		logger.Infof("Determined True (*filesPanel).isRoot(%s)", "nb")
 		if this.refreshSD() {
-			logger.Infof("Determined True (*filesPanel).refreshSD(%s)", "nb")
 			this.addRootLocations()
 		} else {
-			logger.Infof("Determined False (*filesPanel).refreshSD(%s)", "nb")
 			this.locationHistory = utils.LocationHistory {
 				Locations: []dataModels.Location{dataModels.Local},
 			}
 		}
 	}
-	
 	if !this.isRoot() {
-		logger.Infof("Determined False (*filesPanel).isRoot()", "nb")
 		sortedFiles := this.getSortedFiles()
 		this.addSortedFiles(sortedFiles)
 	}
-
 	this.listBox.ShowAll()
-	logger.Infof("End (*filesPanel).doLoadFiles()", "nb")
 }
 
 func (this *filesPanel) refreshSD() bool {


### PR DESCRIPTION
Attempts to refresh the SD and checks it's state when it's determined it should show root locations.

If the SD is not `ready`, it does one of two things depending on what is occurring:
- If we are just entering the `filesPanel`, it automatically enters `local`.
- If we are iterating backwards out of `local`, it proceeds to the previous panel.

This check happens every time you enter the `filesPanel`, so if you insert an SD card prior to entering the panel, OR insert an SD card while in `local` and go `Back`, it will detect the presence of an SD and display both options.

This fully fleshes the the SD support, as it correctly behaves with the possible `404` response from OctoPrint if [SD Support](https://docs.octoprint.org/en/master/api/printer.html#retrieve-the-current-sd-state) is disabled (which is a thing).