### PR TITLE
Bf/config log level

### DIFF
--- a/main.go
+++ b/main.go
@@ -145,7 +145,7 @@ func main() {
 
 
 func setLogLevel() {
-	logLevel := logger.LogLevel()
+	logLevel := strings.ToLower(os.Getenv(utils.EnvLogLevel))
 
 	switch logLevel {
 		case "debug":


### PR DESCRIPTION
Potentially resolves #253 .

I am not sure WHY this was an issue, but...  We literally never used the configured log level...  Also, this single line I changed...  It just read the current log level and set it back...  I feel like I am missing something...