### PR TITLE
Increase Watchdog timer per documentation recomendations.

### DIFF
--- a/debian/octoscreen.service
+++ b/debian/octoscreen.service
@@ -11,7 +11,7 @@ ExecStart=/usr/bin/xinit /usr/bin/OctoScreen -- :0 -nolisten tcp -nocursor
 ExecStartPost=/bin/bash /etc/octoscreen/disablescreenblank.sh 0
 StandardOutput=journal
 Restart=always
-WatchdogSec=10s
+WatchdogSec=20s
 
 [Install]
 WantedBy=graphical.target

--- a/ui/FilesPanel.go
+++ b/ui/FilesPanel.go
@@ -104,6 +104,9 @@ func (this *filesPanel) createBackButton() *gtk.Button {
 }
 
 func (this *filesPanel) doLoadFiles() {
+	
+	this.UI.sdNotify(daemon.SdNotifyWatchdog)
+	
 	utils.EmptyTheContainer(&this.listBox.Container)
 
 	if this.displayRootLocations() {
@@ -130,8 +133,6 @@ func (this *filesPanel) getSortedFiles() []*dataModels.FileResponse {
 	if this.displayRootLocations() {
 		return nil
 	}
-	
-	this.UI.sdNotify(daemon.SdNotifyWatchdog)
 
 	current := this.locationHistory.CurrentLocation()
 	logger.Infof("Loading list of files from: %s", string(current))

--- a/ui/FilesPanel.go
+++ b/ui/FilesPanel.go
@@ -130,6 +130,8 @@ func (this *filesPanel) getSortedFiles() []*dataModels.FileResponse {
 	if this.displayRootLocations() {
 		return nil
 	}
+	
+	this.UI.sdNotify(daemon.SdNotifyWatchdog)
 
 	current := this.locationHistory.CurrentLocation()
 	logger.Infof("Loading list of files from: %s", string(current))
@@ -246,15 +248,11 @@ func (this *filesPanel) createRootLocationButton(location dataModels.Location) *
 
 	rootLocationButton, _ := gtk.ButtonNew()
 	rootLocationButton.Connect("clicked", func() {
-		this.UI.sdNotify(daemon.SdNotifyWatchdog)
-
 		this.locationHistory = utils.LocationHistory {
 			Locations: []dataModels.Location{location},
 		}
 
 		this.doLoadFiles()
-
-		this.UI.sdNotify(daemon.SdNotifyReady)
 	})
 
 	rootLocationButton.Add(topBox)

--- a/ui/ui.go
+++ b/ui/ui.go
@@ -156,8 +156,6 @@ var errMercyPeriod = time.Second * 10
 func (this *UI) verifyConnection() {
 	logger.TraceEnter("ui.verifyConnection()")
 
-	this.sdNotify(daemon.SdNotifyWatchdog)
-
 	newUIState := "<<uninitialized-state>>"
 	splashMessage := "<<uninitialized-message>>"
 
@@ -426,10 +424,11 @@ func (this *UI) validateMenuItems(menuItems []dataModels.MenuItem, name string, 
 func (this *UI) update() {
 	logger.TraceEnter("ui.update()")
 
+	this.sdNotify(daemon.SdNotifyWatchdog)
+	
 	if this.connectionAttempts > 8 {
 		logger.Info("ui.update() - this.connectionAttempts > 8")
 		this.splashPanel.putOnHold()
-		this.sdNotify(daemon.SdNotifyWatchdog)
 
 		logger.TraceLeave("ui.update()")
 		return


### PR DESCRIPTION
The documentation for SdNotify make it very clear that we should be notifying the watchdog at least time/2 (which is to say [WatchdogSec/2].

The primary loop that has done this was `UI.update` although I see that additional calls were added to try to resolve the random reboots.  The fact of the matter is, the timer was 10 seconds, and update was only called every 10 seconds...  So...  A delay of even a second, anywhere in the app, and the watchdog would restart the service.

I see where some additional notifys were added, but to be honest, a 10 second timeout seems too short anyway, and cutting it so close was a gamble.  So I raised the timeout, and while I did keep the notify in Files (although I did move it to what was really the heavy call), with the additional time, I don't really think it is nessesary.

This additional buffer, and adhering to the documented call cadence, should resolve the random reboots (I know 2.7.0 was supposed to resolve these, likely due to the addition of the additional notify calls, however I just had a development board doing nothing reset, so...).

Also, there was a Notify Ready in Files.  That is reserved for Service Init, so I pulled that out.