### PR TITLE
Automatic Resolution Detection

### DIFF
--- a/debian/local/octoscreen/config
+++ b/debian/local/octoscreen/config
@@ -49,4 +49,6 @@ OCTOSCREEN_LOG_LEVEL=Error
 # screen, for example 800x480.
 OCTOSCREEN_RESOLUTION=800x480
 # OCTOSCREEN_RESOLUTION is optional and defaults to 800x480 if missing
+# Set to AUTO to enable automatic display resolution detection
+# Minimum resolution is 548x348
 # (defined in globalVars.go)

--- a/ui/ui.go
+++ b/ui/ui.go
@@ -53,6 +53,12 @@ func New(endpoint, key string, width, height int) *UI {
 		width = utils.WindowWidth
 		height = utils.WindowHeight
 	}
+	
+	if width < 548 || height < 348 {
+		logger.Errorf("Resolution is not within minumum limits.  Resolution must be greater than 548x348.  Target width and height: %dx%d",
+			width,
+			height)
+	}
 
 	instance := &UI {
 		PanelHistory:				stack.New(),


### PR DESCRIPTION
Added support for OCTOSCREEN_RESOLUTION=AUTO which uses `xrandr` to detect the default display resolution automatically.

Additionally, added check and error reporting for minimum resolution requirements.

Kind of inspired by issues such as #246, but probably not exactly a resolution to those issues, as the screen it's self still needs to be configured correctly.

This has been compiled and is running on all of my systems and behaves as expected.