### PR TITLE
Fix the 'FatalErrorWindow' to... BE a Window...

### DIFF
--- a/logger/logger.go
+++ b/logger/logger.go
@@ -169,6 +169,15 @@ func Errorf(format string, args ...interface{}) {
 }
 
 
+func Panic(args ...interface{}) {
+	_logrusEntry.Panic(readIndentation() + fmt.Sprint(args...))
+}
+
+func Panicf(format string, args ...interface{}) {
+	_logrusEntry.Panicf(readIndentation() + format, args...)
+}
+
+
 func Fatal(args ...interface{}) {
 	_logrusEntry.Fatal(readIndentation() + fmt.Sprint(args...))
 }

--- a/ui/ErrorWindow.go
+++ b/ui/ErrorWindow.go
@@ -6,13 +6,13 @@ import (
 	// "github.com/Z-Bolt/OctoScreen/utils"
 )
 
-func CreateFatalErrorWindow(message string, description string) *gtk.Window {
+func CreateErrorWindow(message string, description string) *gtk.Window {
 	window, error := gtk.WindowNew(gtk.WINDOW_TOPLEVEL)
 	if error != nil {
-		logger.LogFatalError("FatalErrorWindow.CreateFatalErrorWindow()", "WindowNew()", error)
+		logger.LogError("ErrorWindow.CreateErrorWindow()", "WindowNew()", error)
 	}
 
-	window.SetTitle("Fatal Error")
+	window.SetTitle("Error")
 	window.Connect("destroy", func() {
 		gtk.MainQuit()
 	})
@@ -22,7 +22,7 @@ func CreateFatalErrorWindow(message string, description string) *gtk.Window {
 	// Create a new label widget to show in the window.
 	label, error := gtk.LabelNew("\n    " + message + "\n    " + description)
 	if error != nil {
-		logger.LogFatalError("FatalErrorWindow.CreateFatalErrorWindow()", "LabelNew()", error)
+		logger.LogError("ErrorWindow.CreateErrorWindow()", "LabelNew()", error)
 	}
 
 	label.SetHAlign(gtk.ALIGN_START)

--- a/ui/ui.go
+++ b/ui/ui.go
@@ -399,11 +399,11 @@ func (this *UI) validateMenuItems(menuItems []dataModels.MenuItem, name string, 
 			description = fmt.Sprintf("\n    When the MenuStructure for '%s' was parsed,\n    %d items were found.", name, menuItemsLength)
 		}
 
-		fatalErrorWindow := CreateFatalErrorWindow(
+		errorWindow := CreateErrorWindow(
 			message,
 			description,
 		)
-		fatalErrorWindow.ShowAll()
+		errorWindow.ShowAll()
 
 		logger.TraceLeave("ui.validateMenuItems()")
 		return false


### PR DESCRIPTION
The previous incantation of this process didn't really do anything of use.  It made a window, but, because it called 'LogFatalError', the program IMMEDIATLY quit, without displaying the error.

Beyond making it NOT display a window, if the error had something to do with configuration, this meant that the app was stuck in a restart loop that dumped stack traces to the log ever 2 seconds (unhelpful, and bad).

New behaviour actualy displays an error and leaves it on the screen.  The watchdog will timeout after however long, and the app will restart.  This makes more sense and makes the error display more useful.

TODO: This really should be located in a `defer` inside `main()`, which would allow it to handle PANIC.  Such an implementation would kill the current `gtk` and start a whole new process, and would allow for 'throwing' errors anywhere in the application. This is outside the scope of the BF at this time, but MAY be added if this sits in PR for too long.

Resolves #259 