### PR TITLE
Proper LDFlags use for Version and Build

### DIFF
--- a/ui/CommonPanel.go
+++ b/ui/CommonPanel.go
@@ -15,9 +15,6 @@ import (
 	"github.com/Z-Bolt/OctoScreen/utils"
 )
 
-// OctoScreenVersion - set at compilation time.
-var OctoScreenVersion = "2.7.0"
-
 type CommonPanel struct {
 	UI					*UI
 	grid				*gtk.Grid

--- a/ui/SystemPanel.go
+++ b/ui/SystemPanel.go
@@ -51,7 +51,7 @@ func (this *systemPanel) initialize() {
 	this.octoPrintInfoBox = uiWidgets.CreateOctoPrintInfoBox(this.UI.Client, logoWidth)
 	this.Grid().Attach(this.octoPrintInfoBox,        0, 0, 1, 1)
 
-	this.octoScreenInfoBox = uiWidgets.CreateOctoScreenInfoBox(this.UI.Client, OctoScreenVersion)
+	this.octoScreenInfoBox = uiWidgets.CreateOctoScreenInfoBox(this.UI.Client, Version, Build)
 	this.Grid().Attach(this.octoScreenInfoBox,       1, 0, 2, 1)
 
 	this.octoScreenPluginInfoBox = uiWidgets.CreateOctoScreenPluginInfoBox(this.UI.Client, this.UI.UIState, this.UI.OctoPrintPluginIsAvailable)

--- a/ui/ui.go
+++ b/ui/ui.go
@@ -19,6 +19,7 @@ import (
 	"github.com/Z-Bolt/OctoScreen/utils"
 )
 
+// Set at compile time via -ldflags (See: MakeFile)
 var Version string
 var Build   string
 

--- a/ui/ui.go
+++ b/ui/ui.go
@@ -19,6 +19,8 @@ import (
 	"github.com/Z-Bolt/OctoScreen/utils"
 )
 
+var Version string
+var Build   string
 
 type UI struct {
 	sync.Mutex

--- a/uiWidgets/OctoScreenInfoBox.go
+++ b/uiWidgets/OctoScreenInfoBox.go
@@ -2,7 +2,7 @@ package uiWidgets
 
 import (
 	// "fmt"
-	"strings"
+	//"strings"
 
 	"github.com/Z-Bolt/OctoScreen/octoprintApis"
 	// "github.com/Z-Bolt/OctoScreen/octoprintApis/dataModels"
@@ -15,10 +15,12 @@ type OctoScreenInfoBox struct {
 
 func CreateOctoScreenInfoBox(
 	client				*octoprintApis.Client,
-	octoScreenVersion	string,
+	Version				string,
+	Build				string,
 ) *OctoScreenInfoBox {
 	logoImage := utils.MustImageFromFile("logos/octoscreen-isometric-90%.png")
 
+	/*
 	str2 := ""
 	str3 := ""
 	stringArray := strings.Split(octoScreenVersion, " ")
@@ -29,13 +31,14 @@ func CreateOctoScreenInfoBox(
 		str2 = octoScreenVersion
 		str3 = ""
 	}
+	*/
 
 	base := CreateSystemInfoBox(
 		client,
 		logoImage,
 		"OctoScreen",
-		str2,
-		str3,
+		Version,
+		Build,
 	)
 
 	instance := &OctoScreenInfoBox {


### PR DESCRIPTION
Explicitly uses the `-ldflags` directive for populating `Version` and `Build`.

This was KIND of implied in the original comment, but not exactly.  There shouldn't be multiple places we have to store the version information.  One place is enough.

Ideally, this would be based off from the latest `git tag` on master, but that is for another day.