### PR TITLE
Add glib, pango, and pixbuf tags.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,15 +19,15 @@ DEBIAN_PACKAGES = STRETCH
 
 BUSTER_NAME := buster
 BUSTER_IMAGE := golang:1.15-buster
-BUSTER_GO_TAGS := gtk_3_24
+BUSTER_GO_TAGS := gtk_3_22,glib_2_58,pango_1_42,gdk_pixbuf_2_38
 
 STRETCH_NAME := stretch
-STRETCH_IMAGE := golang:1.9-stretch
-STRETCH_GO_TAGS := gtk_3_22
+STRETCH_IMAGE := golang:1.15-stretch
+STRETCH_GO_TAGS := gtk_3_22,glib_2_50,pango_1_40,gdk_pixbuf_2_36
 
 JESSIE_NAME := jessie
 JESSIE_IMAGE := golang:1.8-jessie
-JESSIE_GO_TAGS := gtk_3_14
+JESSIE_GO_TAGS := gtk_3_14,glib_2_42,pango_1_36,gdk_pixbuf_2_31
 
 
 # Build information


### PR DESCRIPTION
This upgrades the Golang version for `STRETCH` to the latest supported, downgrades the `BUSTER` tag for `gtk` to avoid a weird linker issue I discovered in `golang1.16` that **may** not be necessary, but also doesn't break anything, and ADDS various supported tags for `glib`, `pango` an `pixbuf`.

Now, you may be wondering why these changes are needed.  Well, they don't break anything, and they WILL be needed if and when we upgrade to the latest version of `gotk3`.  I already have a working branch with `gotk3` in it, I am just not pulling ALL of those changes in one go (for sanities sake), and instead I'll give you some foundational things first.

Mazel