### PR TITLE
Go.Mod stub

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/Z-Bolt/OctoScreen
+
+go 1.14


### PR DESCRIPTION
Must be over 1.14 to trigger automatic vendoring for potential linter usage.

Does not impact building for JESSIE, or the build process as it is currently executed.

Does set the stage for simplifying the build process, however (no need for copying the whole system to go-root, path trimming, etc).

This lacks the "required" modules for a reason, we should discuss that reason before merging this.