### PR TITLE
Drain request body before closing

### DIFF
--- a/octoprintApis/client.go
+++ b/octoprintApis/client.go
@@ -140,7 +140,10 @@ func (this *Client) handleResponse(
 ) ([]byte, error) {
 	logger.TraceEnter("Client.handleResponse()")
 
-	defer httpResponse.Body.Close()
+	defer func() {
+		io.Copy(ioutil.Discard, httpResponse.Body)
+		httpResponse.Body.Close()
+	}()
 
 	if statusMapping != nil {
 		if err := statusMapping.Error(httpResponse.StatusCode); err != nil {


### PR DESCRIPTION
Drain the request body to enable socket reuse.

This is mostly going to come into play where you check the http.StatusCode and return early without reading the rest of the request body.

After leaving it running for over 24 hours with the printer turned off I only had 34 TIME_WAIT connections instead of the usual crash loop in python from too many sockets.
