### PR TITLE
Add Filament Manager Integration

### DIFF
--- a/octoprintApis/FilamentManager.go
+++ b/octoprintApis/FilamentManager.go
@@ -1,0 +1,5 @@
+package octoprintApis
+
+const FilamentManagerSpoolsUri = "/plugin/filamentmanager/spools"
+const FilamentManagerSelectionsUri = "/plugin/filamentmanager/selections"
+const FilamentManagerSetSelectionUri = "/plugin/filamentmanager/selections/%d"

--- a/octoprintApis/FilamentManagerSelectionsRequest.go
+++ b/octoprintApis/FilamentManagerSelectionsRequest.go
@@ -1,0 +1,31 @@
+//package apis
+package octoprintApis
+
+import (
+	"encoding/json"
+
+	"github.com/Z-Bolt/OctoScreen/logger"
+	"github.com/Z-Bolt/OctoScreen/octoprintApis/dataModels"
+)
+
+
+
+// Fetch the current selections from the FilamentManager Plugin
+type FilamentManagerSelectionsRequest struct {}
+
+// Do sends an API request and returns the API response
+func (request *FilamentManagerSelectionsRequest) Do(c *Client) (*dataModels.FilamentManagerSelections, error) {
+	bytes, err := c.doJsonRequest("GET", FilamentManagerSelectionsUri, nil, nil, true)
+	if err != nil {
+		logger.LogError("FilamentManagerSelectionsRequest.Do()", "client.doJsonRequest(GET)", err)
+		return nil, err
+	}
+
+	response := &dataModels.FilamentManagerSelections{}
+	if err := json.Unmarshal(bytes, response); err != nil {
+		logger.LogError("FilamentManagerSelectionsRequest.Do()", "json.Unmarshal()", err)
+		return nil, err
+	}
+
+	return response, err
+}

--- a/octoprintApis/FilamentManagerSetSelectionRequest.go
+++ b/octoprintApis/FilamentManagerSetSelectionRequest.go
@@ -1,0 +1,66 @@
+//package apis
+package octoprintApis
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+
+	"github.com/Z-Bolt/OctoScreen/logger"
+	"github.com/Z-Bolt/OctoScreen/octoprintApis/dataModels"
+)
+
+// Set the current selections for the given tool to the specified spool
+type FilamentManagerSetSelectionRequest struct {
+	// Tool ID
+	Tool int
+
+	// Spool Id
+	Spool int
+}
+
+func (request *FilamentManagerSetSelectionRequest) Do(c *Client) (*dataModels.FilamentManagerSelection, error) {
+	buffer := bytes.NewBuffer(nil)
+	uri := fmt.Sprintf(FilamentManagerSetSelectionUri, request.Tool)
+
+	if err := request.encode(buffer); err != nil {
+		logger.LogError("FilamentManagerSetSelectionRequest.Do()", "request.encode(buffer)", err)
+		return nil, err
+	}
+
+	resp, err := c.doJsonRequest("PATCH", uri, buffer, nil, true)
+	if err != nil {
+		logger.Infof("doJsonRequest(PATCH)=>%v", string(resp[:]))
+		logger.LogError("FilamentManagerSetSelectionRequest.Do()", "client.doJsonRequest(PATCH)", err)
+		return nil, err
+	}
+
+	response := &dataModels.FilamentManagerSelection{}
+	if err := json.Unmarshal(resp, response); err != nil {
+		logger.LogError("FilamentManagerSetSelectionRequests.Do()", "json.Unmarshal()", err)
+		return nil, err
+	}
+
+	return response, err
+}
+
+// The actual PATCH structure expected is a bit unusual, so just convert under
+// the hood
+type FilamentManagerSetSelectionRequestJson struct {
+	Selection struct {
+		Tool int `json:"tool"`
+		Spool struct {
+			Id int `json:"id"`
+		} `json:"spool"`
+	} `json:"selection"`
+}
+
+func (request *FilamentManagerSetSelectionRequest) encode(w io.Writer) error {
+	req := FilamentManagerSetSelectionRequestJson{}
+
+	req.Selection.Tool = request.Tool
+	req.Selection.Spool.Id = request.Spool
+
+	return json.NewEncoder(w).Encode(req)
+}

--- a/octoprintApis/FilamentManagerSpoolsRequest.go
+++ b/octoprintApis/FilamentManagerSpoolsRequest.go
@@ -1,0 +1,29 @@
+//package apis
+package octoprintApis
+
+import (
+	"encoding/json"
+
+	"github.com/Z-Bolt/OctoScreen/logger"
+
+	"github.com/Z-Bolt/OctoScreen/octoprintApis/dataModels"
+)
+
+// Fetch the spools from the FilamentManager Plugin
+type FilamentManagerSpoolsRequest struct {}
+
+func (request *FilamentManagerSpoolsRequest) Do(c *Client) (*dataModels.FilamentManagerSpools, error) {
+	bytes, err := c.doJsonRequest("GET", FilamentManagerSpoolsUri, nil, nil, true)
+	if err != nil {
+		logger.LogError("FilamentManagerSpoolsRequest.Do()", "client.doJsonRequest(GET)", err)
+		return nil, err
+	}
+
+	response := &dataModels.FilamentManagerSpools{}
+	if err := json.Unmarshal(bytes, response); err != nil {
+		logger.LogError("FilamentManagerSpoolsRequest.Do()", "json.Unmarshal()", err)
+		return nil, err
+	}
+
+	return response, err
+}

--- a/octoprintApis/dataModels/FilamentManagerSelections.go
+++ b/octoprintApis/dataModels/FilamentManagerSelections.go
@@ -1,0 +1,16 @@
+package dataModels
+
+type FilamentManagerSelection struct {
+	// Unknown?
+	ClientId string `json: "client_id"`
+
+	// Currently selected spool
+	Spool FilamentManagerSpool `json: "spool"`
+
+	// Tool the spool is selected on
+	Tool int `json: "tool"`
+}
+
+type FilamentManagerSelections struct {
+	Selections []*FilamentManagerSelection `json: "selections"`
+}

--- a/octoprintApis/dataModels/FilamentManagerSpool.go
+++ b/octoprintApis/dataModels/FilamentManagerSpool.go
@@ -1,0 +1,42 @@
+package dataModels
+
+type FilamentManagerSpoolProfile struct {
+	// Filament density
+	Density float64 `json: "density"`
+
+	// Filament diameter
+	Diameter float64 `json: "diameter"`
+
+	// Profile Id
+	Id int `json: "id"`
+
+	// Material name
+	Material string `json: "material"`
+
+	// Spool vendor
+	Vendor string `json: "vendor"`
+}
+
+// ConnectionResponse is the response from a connection command.
+type FilamentManagerSpool struct {
+	// Cost of the spool
+	Cost float64 `json:"cost"`
+
+	// Spool ID
+	Id int `json: id`
+
+	// Name of the spool
+	Name string `json: "name"`
+
+	// Spool profile
+	Profile FilamentManagerSpoolProfile `json: "profile"`
+
+	// Temperature offset of spool
+	TempOffset float64 `json: "temp_offset"`
+
+	// Used filament
+	Used float64 `json: "used"`
+
+	// Starting weight of the spool
+	Weight float64 `json: "Weight"`
+}

--- a/octoprintApis/dataModels/FilamentManagerSpools.go
+++ b/octoprintApis/dataModels/FilamentManagerSpools.go
@@ -1,0 +1,7 @@
+package dataModels
+
+
+// FilamentManagerSpools is the response to a FilamentManagerSpoolsRequest.
+type FilamentManagerSpools struct {
+	Spools    []*FilamentManagerSpool
+}

--- a/styles/z-bolt/style.css
+++ b/styles/z-bolt/style.css
@@ -125,6 +125,43 @@ button.color-none {
 	border-bottom: 8px solid #E6D300;
 }
 
+.color-black {
+	border-bottom: 8px solid black;
+}
+.color-white {
+	border-bottom: 8px solid white;
+}
+.color-red {
+	border-bottom: 8px solid red;
+}
+.color-green {
+	border-bottom: 8px solid green;
+}
+.color-blue {
+	border-bottom: 8px solid blue;
+}
+.color-brown {
+	border-bottom: 8px solid brown;
+}
+.color-yellow {
+	border-bottom: 8px solid yellow;
+}
+.color-gold {
+	border-bottom: 8px solid gold;
+}
+.color-pink {
+	border-bottom: 8px solid pink;
+}
+.color-grey {
+	border-bottom: 8px solid grey;
+}
+.color-lime {
+	border-bottom: 8px solid lime;
+}
+.color-orange {
+	border-bottom: 8px solid orange;
+}
+
 
 
 

--- a/ui/FilamentManagerPanel.go
+++ b/ui/FilamentManagerPanel.go
@@ -1,0 +1,152 @@
+package ui
+
+import (
+	"fmt"
+
+	"github.com/gotk3/gotk3/gtk"
+
+	"github.com/Z-Bolt/OctoScreen/octoprintApis"
+	"github.com/Z-Bolt/OctoScreen/octoprintApis/dataModels"
+	"github.com/Z-Bolt/OctoScreen/utils"
+)
+
+var filamentManagerPanelInstance *filamentManagerPanel
+
+// This page acts as the dispatch to change the filament on a specific tool.
+// Many users won't see this page at all
+
+type filamentManagerPanel struct {
+	CommonPanel
+
+	listBox				*gtk.Box
+
+	// this is mostly to make alternating colors easier
+	toolCount int
+}
+
+func FilamentManagerPanel(
+	ui				*UI,
+) *filamentManagerPanel {
+	if filamentManagerPanelInstance == nil {
+		instance := &filamentManagerPanel {
+			CommonPanel: NewCommonPanel("FilamentManagerPanel", ui),
+		}
+		instance.initialize()
+		filamentManagerPanelInstance = instance
+	}
+
+	return filamentManagerPanelInstance
+}
+
+func (this *filamentManagerPanel) initialize() {
+	this.listBox = utils.MustBox(gtk.ORIENTATION_VERTICAL, 0)
+	this.listBox.SetVExpand(true)
+
+	scroll, _ := gtk.ScrolledWindowNew(nil, nil)
+	scroll.SetProperty("overlay-scrolling", false)
+	scroll.Add(this.listBox)
+
+	box := utils.MustBox(gtk.ORIENTATION_VERTICAL, 0)
+	box.Add(scroll)
+	box.Add(this.createActionFooter())
+	this.Grid().Add(box)
+
+	this.doLoad()
+}
+
+func (this *filamentManagerPanel) createActionFooter() *gtk.Box {
+	actionBar := utils.MustBox(gtk.ORIENTATION_HORIZONTAL, 5)
+	actionBar.SetHAlign(gtk.ALIGN_END)
+	actionBar.SetHExpand(true)
+	actionBar.SetMarginTop(5)
+	actionBar.SetMarginBottom(5)
+	actionBar.SetMarginEnd(5)
+	
+	backImage := utils.MustImageFromFileWithSize("back.svg", this.Scaled(40), this.Scaled(40))
+	backButton := utils.MustButton(backImage, func() {
+		this.UI.GoToPreviousPanel()
+	})
+
+	actionBar.Add(backButton)
+
+	return actionBar
+}
+
+func (this *filamentManagerPanel) loadSelections() *dataModels.FilamentManagerSelections {
+	request := &octoprintApis.FilamentManagerSelectionsRequest {}
+	response, _ := request.Do(this.UI.Client)
+
+	return response
+}
+
+func (this *filamentManagerPanel) doLoad() {
+	utils.EmptyTheContainer(&this.listBox.Container)
+	this.toolCount = 0
+
+	selections := this.loadSelections()
+
+	if len(selections.Selections) == 0 {
+		listBoxRow, _ := gtk.ListBoxRowNew()
+
+		nameLabel := utils.MustLabel("Tool")
+		nameLabel.SetMarkup("Filament Manager is not configured, or no spools are loaded")
+		nameLabel.SetHExpand(true)
+		nameLabel.SetHAlign(gtk.ALIGN_START)
+
+		listBoxRow.Add(nameLabel)
+
+		this.listBox.Add(listBoxRow)
+	} else {
+		for _, selection := range selections.Selections {
+			this.addToolhead(selection)
+		}
+	}
+}
+
+func (this *filamentManagerPanel) addToolhead(selection *dataModels.FilamentManagerSelection) {
+	listBoxRow, _ := gtk.ListBoxRowNew()
+
+	image := utils.MustImageFromFileWithSize("extruder.svg", this.Scaled(45), this.Scaled(45))
+
+	topBox := utils.MustBox(gtk.ORIENTATION_HORIZONTAL, 5)
+	topBox.Add(image)
+
+	labelsBox := utils.MustBox(gtk.ORIENTATION_VERTICAL, 5)
+	labelsBox.SetVExpand(false)
+	labelsBox.SetVAlign(gtk.ALIGN_CENTER)
+	labelsBox.SetHAlign(gtk.ALIGN_START)
+	labelsBoxStyleContext, _ := labelsBox.GetStyleContext()
+	labelsBoxStyleContext.AddClass("labels-box")
+
+	nameLabel := utils.MustLabel("Tool")
+	nameLabel.SetMarkup(fmt.Sprintf("<big>Tool %d: %s</big>",
+		selection.Tool, selection.Spool.Name))
+	nameLabel.SetHExpand(true)
+	nameLabel.SetHAlign(gtk.ALIGN_START)
+	labelsBox.Add(nameLabel)
+
+	spoolLabel := utils.MustLabel("")
+	spoolLabel.SetHAlign(gtk.ALIGN_START)
+	spoolLabel.SetMarkup(fmt.Sprintf("<small>Spool: %s by %s | Material: %s</small>",
+		selection.Spool.Name, selection.Spool.Profile.Vendor, selection.Spool.Profile.Material))
+	labelsBox.Add(spoolLabel)
+
+	usageLabel := utils.MustLabel("")
+	usageLabel.SetHAlign(gtk.ALIGN_START)
+	usageLabel.SetMarkup(fmt.Sprintf("<small>Used: %.0f/%.0fg</small>",
+		selection.Spool.Used, selection.Spool.Weight))
+	labelsBox.Add(usageLabel)
+
+
+	topBox.Add(labelsBox)
+
+	button, _ := gtk.ButtonNew()
+	button.Connect("clicked", func() {
+		this.UI.GoToPanel(FilamentManagerToolPanel(this.UI, selection))
+	})
+
+	button.Add(topBox)
+
+	listBoxRow.Add(button)
+	this.listBox.Add(listBoxRow)
+}

--- a/ui/FilamentManagerToolPanel.go
+++ b/ui/FilamentManagerToolPanel.go
@@ -1,0 +1,322 @@
+package ui
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/gotk3/gotk3/gtk"
+
+	"github.com/Z-Bolt/OctoScreen/logger"
+	"github.com/Z-Bolt/OctoScreen/octoprintApis"
+	"github.com/Z-Bolt/OctoScreen/octoprintApis/dataModels"
+	"github.com/Z-Bolt/OctoScreen/utils"
+)
+
+var filamentToolPanelInstance *filamentManagerToolPanel
+
+type filamentManagerToolPanel struct {
+	CommonPanel
+	tool *dataModels.FilamentManagerSelection
+
+	listBox					*gtk.Box
+	toolName				*gtk.Label
+	selected				*gtk.Label
+	vendor					*gtk.Label
+	used					*gtk.Label
+	cost					*gtk.Label
+
+	spoolCount int
+}
+
+func FilamentManagerToolPanel(
+	ui *UI,
+	tool *dataModels.FilamentManagerSelection,
+) *filamentManagerToolPanel {
+	if filamentToolPanelInstance == nil {
+		instance := &filamentManagerToolPanel {
+			CommonPanel:		NewCommonPanel("FilamentToolPanel", ui),
+		}
+		instance.initialize()
+		filamentToolPanelInstance = instance
+	} else {
+		filamentToolPanelInstance.tool = tool
+		// be sure to refresh the labels/spools when reopening the panel
+		filamentToolPanelInstance.update()
+	}
+
+	return filamentToolPanelInstance
+}
+
+func (this *filamentManagerToolPanel) initialize() {
+	panel := utils.MustGrid()
+	panel.Attach(this.createToolbar(), 0, 0, 1, 1)
+
+	rows := utils.MustBox(gtk.ORIENTATION_VERTICAL, 5)
+	rows.Add(this.createSpoolListWindow())
+
+	actionBar := utils.MustBox(gtk.ORIENTATION_HORIZONTAL, 5)
+	actionBar.SetHAlign(gtk.ALIGN_END)
+
+	backImage := utils.MustImageFromFileWithSize("back.svg",
+		this.Scaled(40), this.Scaled(40))
+	backButton := utils.MustButton(backImage, func() {
+		this.UI.GoToPreviousPanel()
+	})
+	backButton.SetMarginEnd(10)
+	actionBar.Add(backButton)
+
+	rows.Add(actionBar)
+	panel.Attach(rows, 1, 0, 5, 1)
+
+	this.Grid().Attach(panel, 1, 1, 1, 1)
+
+	this.update()
+}
+
+func (this *filamentManagerToolPanel) update() {
+	logger.TraceEnter("filamentManagerToolPanel.update()")
+
+	utils.EmptyTheContainer(&this.listBox.Container)
+	this.spoolCount = 0
+
+	this.updateLabels()
+	this.updateSpools()
+	this.listBox.ShowAll()
+
+	logger.TraceLeave("filamentManagerToolPanel.update()")
+}
+
+func (this *filamentManagerToolPanel) updateLabels() {
+	// This could be optimized to just request the current tool
+	request := &octoprintApis.FilamentManagerSelectionsRequest {}
+	response, _ := request.Do(this.UI.Client)
+
+	for _, selection := range response.Selections {
+		if this.tool == nil || selection.Tool == this.tool.Tool {
+			this.tool = selection
+			break
+		}
+	}
+
+	this.toolName.SetText(fmt.Sprintf("Tool %d", this.tool.Tool))
+	this.selected.SetText(fmt.Sprintf("Spool: %s", this.tool.Spool.Name))
+	this.vendor.SetText(fmt.Sprintf("Brand: %s", this.tool.Spool.Profile.Vendor))
+	this.used.SetText(fmt.Sprintf("Used: %.0fg/%.0fg",
+		this.tool.Spool.Used, this.tool.Spool.Weight))
+	// TODO check how to get currency units
+	this.cost.SetText(fmt.Sprintf("Cost: %.0f", this.tool.Spool.Cost))
+
+	// in case the spool change, updated the color
+	color := getSpoolColor(&this.tool.Spool)
+	if color != "" {
+		style, _ := this.selected.GetStyleContext()
+		style.AddClass(color)
+	}
+}
+
+func (this *filamentManagerToolPanel) updateSpools() {
+	request := &octoprintApis.FilamentManagerSpoolsRequest {}
+	response, _ := request.Do(this.UI.Client)
+
+	for _, spool := range response.Spools {
+		this.addSpool(this.listBox, spool)
+	}
+}
+
+func (this *filamentManagerToolPanel) createSpoolListWindow() gtk.IWidget {
+	this.listBox = utils.MustBox(gtk.ORIENTATION_VERTICAL, 0)
+	this.listBox.SetVExpand(true)
+
+	box := utils.MustBox(gtk.ORIENTATION_VERTICAL, 0)
+
+	spoolListWindow, _ := gtk.ScrolledWindowNew(nil, nil)
+	spoolListWindow.SetProperty("overlay-scrolling", false)
+	spoolListWindow.Add(this.listBox)
+	box.Add(spoolListWindow)
+
+	return box
+}
+
+func (this *filamentManagerToolPanel) createToolbar() gtk.IWidget {
+	toolbar := utils.MustBox(gtk.ORIENTATION_VERTICAL, 5)
+	toolbar.SetHExpand(true)
+
+	toolbar.Add(this.createInfoBar())
+
+	return toolbar
+}
+
+func (this *filamentManagerToolPanel) createInfoBar() gtk.IWidget {
+	infoBar := utils.MustBox(gtk.ORIENTATION_VERTICAL, 5)
+	infoBar.SetVExpand(true)
+	infoBar.SetVAlign(gtk.ALIGN_START)
+	infoBar.SetHAlign(gtk.ALIGN_START)
+
+	infoBar.SetMarginEnd(25)
+	infoBar.SetMarginStart(25)
+
+	t1 := utils.MustLabel("<big><b>Tool Information</b></big>")
+	t1.SetHAlign(gtk.ALIGN_START)
+	t1.SetMarginTop(25)
+
+	infoBar.Add(t1)
+
+	this.toolName = utils.MustLabel("")
+	this.toolName.SetHAlign(gtk.ALIGN_START)
+	infoBar.Add(this.toolName)
+
+	extruder := utils.MustImageFromFileWithSize("extruder.svg",
+		this.Scaled(50), this.Scaled(50))
+	extruder.SetHAlign(gtk.ALIGN_CENTER)
+	infoBar.Add(extruder)
+
+	t2 := utils.MustLabel("<b>Filament Information</b>")
+	t2.SetHAlign(gtk.ALIGN_START)
+	t2.SetMarginTop(25)
+	infoBar.Add(t2)
+
+	this.selected = utils.MustLabel("Name")
+	this.selected.SetHAlign(gtk.ALIGN_START)
+	this.selected.SetMarginTop(25)
+	infoBar.Add(this.selected)
+
+	this.vendor = utils.MustLabel("Vendor")
+	this.vendor.SetHAlign(gtk.ALIGN_START)
+	infoBar.Add(this.vendor)
+
+	this.used = utils.MustLabel("Used Filament:")
+	this.used.SetHAlign(gtk.ALIGN_START)
+	infoBar.Add(this.used)
+
+	this.cost = utils.MustLabel("Cost:")
+	this.cost.SetHAlign(gtk.ALIGN_START)
+	infoBar.Add(this.cost)
+
+
+	return infoBar
+}
+
+func (this *filamentManagerToolPanel) addSpoolInfo(spool *dataModels.FilamentManagerSpool) *gtk.Box {
+	infoBox := utils.MustBox(gtk.ORIENTATION_VERTICAL, 5)
+	infoBox.SetVExpand(true)
+	infoBox.SetHExpand(true)
+	infoBox.SetHAlign(gtk.ALIGN_START)
+	infoBoxStyleContext, _ := infoBox.GetStyleContext()
+	infoBoxStyleContext.AddClass("labels-box")
+
+	name := utils.MustLabel(spool.Name)
+	name.SetHAlign(gtk.ALIGN_START)
+	name.SetMarkup(fmt.Sprintf("<big>%s</big>", utils.TruncateString(spool.Name, 24)))
+	infoBox.Add(name)
+
+	material := utils.MustLabel("")
+	material.SetHAlign(gtk.ALIGN_START)
+	material.SetMarkup(fmt.Sprintf("<small>Material: %s</small>",
+		spool.Profile.Material))
+	infoBox.Add(material)
+
+	usage := utils.MustLabel("")
+	usage.SetHAlign(gtk.ALIGN_START)
+	usage.SetMarkup(fmt.Sprintf("<small>Used: %.0f/%.0fg</small>",
+		spool.Used, spool.Weight))
+	infoBox.Add(usage)
+
+	brand := utils.MustLabel("")
+	brand.SetHAlign(gtk.ALIGN_START)
+	brand.SetMarkup(fmt.Sprintf("<small>Brand: %s</small>", spool.Profile.Vendor))
+	infoBox.Add(brand)
+
+	return infoBox
+}
+
+func (this *filamentManagerToolPanel) addSpool(box *gtk.Box, spool *dataModels.FilamentManagerSpool) {
+	spoolRow := utils.MustBox(gtk.ORIENTATION_HORIZONTAL, 0)
+	spoolRow.SetVExpand(true)
+	spoolRow.SetHExpand(true)
+
+	clicked := func() {
+		// TODO: verify we aren't currently printing
+		request := &octoprintApis.FilamentManagerSetSelectionRequest {}
+		request.Tool = this.tool.Tool
+		request.Spool = spool.Id
+
+		_, err := request.Do(this.UI.Client)
+		if err != nil {
+			logger.LogError("filamentManagerToolPanel.addSpool()", "Do(FilamentManagerSetSelectionRequest)", err)
+			utils.ErrorMessageDialogBox(this.UI.window, 
+				fmt.Sprintf("Unable to change filament: %v", err))
+		} else {
+			// possible optimization, use the response from FilamentManagerSetSelectionRequest
+			// (a FilamentManagerSelection) to do the update to avoid the extra round
+			// trip
+			this.update()
+		}
+	}
+
+	image := utils.MustImageFromFileWithSize("filament-spool.svg", this.Scaled(25), this.Scaled(25))
+
+	color := getSpoolColor(spool)
+	if color != "" {
+		style, _ := image.GetStyleContext()
+		style.AddClass(color)
+	}
+	rowButton := utils.MustButton(image, clicked)
+	spoolRow.Add(rowButton)
+
+	if spool.Id == this.tool.Spool.Id {
+		extruder := utils.MustImageFromFileWithSize("extruder.svg", this.Scaled(25), this.Scaled(25))
+		spoolRow.Add(extruder)
+	}
+
+	/*
+	I tried adding the whole row was a button, but it broke all of my
+	formatting
+	*/
+
+	spoolRow.Add(this.addSpoolInfo(spool))
+
+	if this.spoolCount % 2 != 0 {
+		styleContext, _ := spoolRow.GetStyleContext()
+		styleContext.AddClass("list-item-nth-child-even")
+	}
+	this.spoolCount++
+
+	box.Add(spoolRow)
+	this.listBox.Add(box)
+}
+
+
+func getSpoolColor(spool *dataModels.FilamentManagerSpool) string {
+	var color string = ""
+
+	name := strings.ToLower(spool.Name)
+
+	if strings.Contains(name, "black") {
+		// skip setting for black since black on black won't be seen
+		color = ""
+	} else if strings.Contains(name, "white") {
+		color = "color-white"
+	} else if strings.Contains(name, "red") {
+		color = "color-red"
+	} else if strings.Contains(name, "green") {
+		color = "color-green"
+	} else if strings.Contains(name, "blue") {
+		color = "color-blue"
+	} else if strings.Contains(name, "brown") {
+		color = "color-brown"
+	} else if strings.Contains(name, "yellow") {
+		color = "color-yellow"
+	} else if strings.Contains(name, "gold") {
+		color = "color-gold"
+	} else if strings.Contains(name, "pink") {
+		color = "color-pink"
+	} else if strings.Contains(name, "grey") {
+		color = "color-grey"
+	} else if strings.Contains(name, "lime") {
+		color = "color-lime"
+	} else if strings.Contains(name, "orange") {
+		color = "color-orange"
+	}
+
+	return color
+}

--- a/ui/FilamentManagerToolPanel.go
+++ b/ui/FilamentManagerToolPanel.go
@@ -21,6 +21,7 @@ type filamentManagerToolPanel struct {
 	listBox					*gtk.Box
 	toolName				*gtk.Label
 	selected				*gtk.Label
+	material				*gtk.Label
 	vendor					*gtk.Label
 	used					*gtk.Label
 	cost					*gtk.Label
@@ -100,6 +101,7 @@ func (this *filamentManagerToolPanel) updateLabels() {
 
 	this.toolName.SetText(fmt.Sprintf("Tool %d", this.tool.Tool))
 	this.selected.SetText(fmt.Sprintf("Spool: %s", this.tool.Spool.Name))
+	this.material.SetText(fmt.Sprintf("Material: %s", this.tool.Spool.Profile.Material))
 	this.vendor.SetText(fmt.Sprintf("Brand: %s", this.tool.Spool.Profile.Vendor))
 	this.used.SetText(fmt.Sprintf("Used: %.0fg/%.0fg",
 		this.tool.Spool.Used, this.tool.Spool.Weight))
@@ -179,6 +181,10 @@ func (this *filamentManagerToolPanel) createInfoBar() gtk.IWidget {
 	this.selected.SetHAlign(gtk.ALIGN_START)
 	this.selected.SetMarginTop(25)
 	infoBar.Add(this.selected)
+
+	this.material = utils.MustLabel("Material")
+	this.material.SetHAlign(gtk.ALIGN_START)
+	infoBar.Add(this.material)
 
 	this.vendor = utils.MustLabel("Vendor")
 	this.vendor.SetHAlign(gtk.ALIGN_START)

--- a/ui/FilamentPanel.go
+++ b/ui/FilamentPanel.go
@@ -45,14 +45,14 @@ func FilamentPanel(
 		}
 		instance.initialize()
 		filamentPanelInstance = instance
+	} else {
+		filamentPanelInstance.drawPanel()
 	}
 
 	return filamentPanelInstance
 }
 
-func (this *filamentPanel) initialize() {
-	defer this.Initialize()
-
+func (this *filamentPanel) drawPanel() {
 	// Create the step buttons first, since they are needed by some of the other controls.
 	this.flowRateStepButton = uiWidgets.CreateFlowRateStepButton(this.UI.Client)
 	this.amountToExtrudeStepButton = uiWidgets.CreateAmountToExtrudeStepButton()
@@ -128,6 +128,11 @@ func (this *filamentPanel) initialize() {
 		this.addFilamentManagerButton(column)
 		column++
 	}
+}
+
+func (this *filamentPanel) initialize() {
+	defer this.Initialize()
+	this.drawPanel()
 }
 
 func (this *filamentPanel) showTemperaturePanel() {

--- a/utils/filament.go
+++ b/utils/filament.go
@@ -99,3 +99,18 @@ func SendExtrudeRrequest(
 
 	return nil
 }
+
+func FilamentManagerPluginIsInstalled(
+	client *octoprintApis.Client,
+) bool {
+	plugin := GetPluginInfo(client, "filamentmanager")
+	if plugin == nil {
+		return false
+	}
+
+	if (plugin.IsEnabled == false) {
+		return false
+	}
+
+	return true
+}

--- a/utils/tools.go
+++ b/utils/tools.go
@@ -273,3 +273,21 @@ func HotendTemperatureIsTooLow(
 
 	return false
 }
+
+func GetPluginInfo(client *octoprintApis.Client, pluginName string) *dataModels.Plugin {
+	request := octoprintApis.PluginManagerInfoRequest{}
+
+	pluginManagerInfoResponse, err := request.Do(client, "")
+	if err != nil {
+		logger.LogError("GetPluginInfo()", "PluginManagerInfoRequest.Do()", err)
+		return nil
+	} else {
+		for i := 0; i < len(pluginManagerInfoResponse.Plugins); i++ {
+			plugin := pluginManagerInfoResponse.Plugins[i]
+			if strings.Compare(plugin.Key, pluginName) == 0 {
+				return &plugin
+			}
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
I use the Filament Manager plugin to track filament usage, and I've found when using OctoScreen taht I often forget to swap the filament because I have to go back to octoprint to change the selected filament.

Anyways, I figured adding an integration for a plugin wouldn't be too difficult, so I through together an integration

Adds:
* Button to the existing Filament panel to navigate to the Filament Manager panel (if plugin is installed)
* Adds Panel to view the Filament Manager status of all tool heads
* Adds Panel to view/set the filament per toolhead
  * If only 1 toolhead is present, the first panel is skipped
* The relevant octoprintApis/dataModels for the 3 API calls we need to make
* Adds a utility to get plugin information (basically wrapping PluginManagerInfoRequest to get info on a single plugin)

Let me know if you have any thoughts or feedback

Examples of the 2 new panels and updated filament panel
![PXL_20210818_154048244](https://user-images.githubusercontent.com/3945675/129928720-51d8c61a-a477-4fa5-b5fb-b2511e75bc2a.jpg)
![PXL_20210817_062602698](https://user-images.githubusercontent.com/3945675/129928741-156d7704-ad5d-408d-ba00-5bd852c069ad.jpg)
![PXL_20210818_032706010](https://user-images.githubusercontent.com/3945675/129928756-0f1cc5f6-1cd6-41f4-a45e-a984d55513a3.jpg)

TODO:

- [ ] Add colored bar under Filament Manager Button
- [ ] Remove spool color underline
- [ ] Fix 1 spool display bug
- [ ] Make full row clickable