### PR TITLE
Fix crash in FilesPanel

### DIFF
--- a/ui/FilesPanel.go
+++ b/ui/FilesPanel.go
@@ -133,8 +133,8 @@ func (this *filesPanel) goBack() {
 	if this.displayRootLocations() {
 		this.UI.GoToPreviousPanel()
 	} else if this.locationHistory.IsRoot() {
-		this.locationHistory.GoBack()
 		if this.sdIsReady() {
+			this.locationHistory.GoBack()
 			this.doLoadFiles()
 		} else {
 			this.UI.GoToPreviousPanel()


### PR DESCRIPTION
Fixes a crash caused by FilesPanel location history getting empty when it shouldn't.

### Repro steps
1. Remove SD card from printer (if inserted)
2. Tap Print
3. Tap the back button
4. Tap Print again
5. Tap a gcode file
6. Press Yes

OctoScreen crashes with "index out of range" at FilesPanel.go, line 444.