### PR TITLE
Increase request timeout

### DIFF
--- a/octoprintApis/client.go
+++ b/octoprintApis/client.go
@@ -35,12 +35,12 @@ type Client struct {
 // 'Access Control' is enabled at OctoPrint configuration an apiKey should be
 // provided (http://docs.octoprint.org/en/master/api/general.html#authorization).
 func NewClient(endpoint, apiKey string) *Client {
-	return &Client {
+	return &Client{
 		Endpoint: endpoint,
 		APIKey:   apiKey,
-		httpClient: &http.Client {
-			Timeout: time.Second * 3,
-			Transport: &http.Transport {
+		httpClient: &http.Client{
+			Timeout: time.Second * 15,
+			Transport: &http.Transport{
 				DisableKeepAlives: true,
 			},
 		},


### PR DESCRIPTION
The HTTP request timeout was set to 3 seconds. That's too low for underpowered devices.
I increased the timeout to 15 seconds.

Reasoning:
Since updating to OctoPrint 1.8, `/api/settings` is taking 5-8 seconds on my RPi Zero 2 for some reason. This broke the preheat buttons and temperature panel because the call kept timing out.