### PR TITLE
Update Build-Depends to use debhelper (>= 9.20160709) instead of dh-s…

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -5,7 +5,7 @@ Maintainer: Debian Go Packaging Team <pkg-go-maintainers@lists.alioth.debian.org
 Uploaders: Máximo Cuadros <aleksei.wm@gmail.com>
 Build-Depends: debhelper (>= 9),
                dh-golang,
-               dh-systemd,
+               debhelper (>= 9.20160709),
                libcairo2-dev (>= 1.14.0),
                libgtk-3-dev (>= 3.14)
 Standards-Version: 4.1.1


### PR DESCRIPTION
…ystemd.

Update Build-Depends to use debhelper (>= 9.20160709) instead of dh-systemd or key it on a newer version of debhelper if you wish.